### PR TITLE
Implement the "three buffer reordering" for real packets

### DIFF
--- a/prototypes/test_get_tiles.ipynb
+++ b/prototypes/test_get_tiles.ipynb
@@ -3,7 +3,7 @@
   {
    "cell_type": "code",
    "execution_count": 161,
-   "id": "fabulous-avatar",
+   "id": "stable-stage",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -13,7 +13,7 @@
   {
    "cell_type": "code",
    "execution_count": 162,
-   "id": "large-elephant",
+   "id": "allied-affiliation",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -27,7 +27,7 @@
   {
    "cell_type": "code",
    "execution_count": 6,
-   "id": "generous-fundamental",
+   "id": "suitable-morrison",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -37,7 +37,7 @@
   {
    "cell_type": "code",
    "execution_count": 112,
-   "id": "thousand-martial",
+   "id": "abroad-powell",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -57,8 +57,31 @@
   },
   {
    "cell_type": "code",
+   "execution_count": 194,
+   "id": "hydraulic-shape",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "(224, 0)"
+      ]
+     },
+     "execution_count": 194,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "x = 1\n",
+    "y_mult, xx = divmod(x, 16)\n",
+    "(240 - xx * 16, y_mult*930) "
+   ]
+  },
+  {
+   "cell_type": "code",
    "execution_count": 184,
-   "id": "joint-relaxation",
+   "id": "textile-lebanon",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -120,7 +143,7 @@
   {
    "cell_type": "code",
    "execution_count": 188,
-   "id": "imposed-theater",
+   "id": "lovely-bikini",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -131,7 +154,7 @@
   {
    "cell_type": "code",
    "execution_count": 189,
-   "id": "northern-falls",
+   "id": "worse-trash",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -142,7 +165,7 @@
   {
    "cell_type": "code",
    "execution_count": 191,
-   "id": "apparent-green",
+   "id": "peripheral-quality",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -164,7 +187,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "geographic-refrigerator",
+   "id": "suitable-chest",
    "metadata": {},
    "outputs": [],
    "source": []

--- a/src/libertem_live/detectors/k2is/decode.py
+++ b/src/libertem_live/detectors/k2is/decode.py
@@ -1,3 +1,5 @@
+from collections import namedtuple
+
 import numba
 import numpy as np
 
@@ -121,3 +123,22 @@ def decode_bulk_uint12_le(inp, out, num_packets, meta_out=None):
             )
 
     return meta_out
+
+
+# Fake object orientation, compatible with Numba
+PacketHeader = namedtuple('PacketHeader', ['frame_id', 'pixel_x_start', 'pixel_y_start'])
+
+
+def make_PacketHeader():
+    return PacketHeader(
+        frame_id=np.zeros(1, dtype=np.uint32),
+        pixel_x_start=np.zeros(1, dtype=np.uint16),
+        pixel_y_start=np.zeros(1, dtype=np.uint16),
+    )
+
+
+# @numba.njit
+def decode_header_into(header_inout: PacketHeader, packet: bytes):
+    byteswap_4_decode(inp=packet[24:28], out=header_inout.frame_id)
+    byteswap_2_decode(inp=packet[28:30], out=header_inout.pixel_x_start)
+    byteswap_2_decode(inp=packet[30:32], out=header_inout.pixel_y_start)

--- a/src/libertem_live/detectors/k2is/proto.py
+++ b/src/libertem_live/detectors/k2is/proto.py
@@ -673,20 +673,20 @@ class MsgReaderThread(ErrThreadMixin, threading.Thread):
                         end_after_idx,
                         end_dataset_after_idx
                     )
+                    packet = packets[i*packet_size:(i+1)*packet_size]
                     if target >= 0:  # happy case
-                        packet = packets[i*packet_size:(i+1)*packet_size]
                         merge_packet(bufs[target], headers[i], packet, offset=self.first_frame_id)
                     elif target == TARGET_STRAGGLER:
                         # skip stragglers for now
                         continue
                     elif target == TARGET_NEXT_TILE:
-                        # TODO carry internally
+                        carryover(tile_carry, packet)
                         c_tiles = True
                     elif target == TARGET_PARTITION_CARRY:
-                        # TODO carry to next get_tiles()
+                        carryover(self.partition_carry, packet)
                         c_partition = True
                     elif target == TARGET_DATASET_CARRY:
-                        # TODO carry to next epoch
+                        carryover(self.dataset_carry, packet)
                         c_dataset = True
                         pass
                     self.recent_frame_id = max(


### PR DESCRIPTION
The happy case is tested and works

TODO: Test all the things that can happen when data gets scrambled
TODO: performance -- not using numba to the fullest extent

## Contributor Checklist:

* [ ] I have added or updated my entry in [the creators.json file](https://github.com/LiberTEM/LiberTEM/blob/master/packaging/creators.json)
* [ ] I have added [a changelog entry](https://github.com/LiberTEM/LiberTEM/tree/master/docs/source/changelog) for my contribution
* [ ] I have added/updated documentation for all user-facing changes
* [ ] I have added/updated test cases

## Reviewer Checklist:

* [ ] `/azp run libertem.libertem-live-data` passed

<!--

Starting by submitting an incomplete pull request (PR) or draft PR is OK. You
can work on the checklist step by step by pushing additional commits into the
PR. Please indicate if you think some items may not be applicable.

You can have a look at [our contributing
docs](https://libertem.github.io/LiberTEM/contributing.html) for more
information on contributing to LiberTEM. Please feel free to ask for
clarification and help, for example in your PR description, with comments or in
our [Gitter channel](https://gitter.im/LiberTEM/Lobby).

Thank you for your contribution!

-->
