### PR TITLE
Use select.select() instead of select.poll()

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,25 @@
+# See https://pre-commit.com for more information
+# See https://pre-commit.com/hooks.html for more hooks
+repos:
+- repo: https://github.com/pre-commit/pre-commit-hooks
+  rev: v3.2.0
+  hooks:
+  - id: trailing-whitespace
+    files: ^src/
+  - id: end-of-file-fixer
+    files: ^src/
+  - id: check-yaml
+  - id: check-added-large-files
+- repo: https://github.com/pycqa/flake8
+  rev: 3.9.2
+  hooks:
+  - id: flake8
+    exclude: ^prototypes/
+- repo: https://github.com/regebro/pyroma
+  rev: "3.2"
+  hooks:
+  - id: pyroma
+- repo: https://github.com/miki725/pre-commit-twine-check
+  rev: '47f7fff'
+  hooks:
+  - id: twine-check

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -28,7 +28,7 @@ sys.path.insert(
     )
 )
 
-import libertem_live
+import libertem_live  # noqa:E402
 
 # -- Project information -----------------------------------------------------
 
@@ -219,5 +219,5 @@ linkcheck_ignore = [
     # Some kind of user agent filtering
     r'^https://pydata.org.*',
     # Freezes the link checker for unknown reasons within CI, hard to reproduce
-    r'http://quantumdetectors.com/wp-content/uploads/2017/01/1532-Merlin-for-EM-Technical-Datasheet-v2.pdf',
+    r'http://quantumdetectors.com/wp-content/uploads/2017/01/1532-Merlin-for-EM-Technical-Datasheet-v2.pdf',  # NOQA:E501
 ]

--- a/scripts/release
+++ b/scripts/release
@@ -5,7 +5,6 @@ import re
 import sys
 import json
 import glob
-import shutil
 import tempfile
 import subprocess
 import contextlib

--- a/src/libertem_live/detectors/merlin/sim.py
+++ b/src/libertem_live/detectors/merlin/sim.py
@@ -480,7 +480,9 @@ class DataSocketServer(ServerThreadMixin, threading.Thread):
                         # the trigger event is set, break out of the loop and
                         # handle the connection below:
                         break
-                    (readable, writable, exceptional) = select.select([connection], [connection], [connection], 0.1)
+                    (readable, writable, exceptional) = select.select(
+                        [connection], [connection], [connection], 0.1
+                    )
                     if readable:
                         # The connection is unidirectional, we don't receive any data
                         # normally, but only send

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,1 +1,2 @@
-import utils  # make sure utils.py can be used in other tests
+# make sure utils.py can be used in other tests
+import utils  # NOQA:F401

--- a/tests/detectors/test_merlin.py
+++ b/tests/detectors/test_merlin.py
@@ -1,7 +1,6 @@
 import functools
 import os
 import time
-from typing_extensions import runtime
 import concurrent.futures
 import socket
 import threading
@@ -141,7 +140,14 @@ def test_acquisition(ltl_ctx, merlin_detector_sim, merlin_ds):
         assert acquisition.shape.nav == merlin_ds.shape.nav
 
     host, port = merlin_detector_sim
-    aq = ltl_ctx.prepare_acquisition('merlin', trigger=trigger, scan_size=(32, 32), host=host, port=port, drain=False)
+    aq = ltl_ctx.prepare_acquisition(
+        'merlin',
+        trigger=trigger,
+        scan_size=(32, 32),
+        host=host,
+        port=port,
+        drain=False
+    )
     udf = SumUDF()
 
     res = ltl_ctx.run_udf(dataset=aq, udf=udf)
@@ -158,7 +164,14 @@ def test_acquisition_cached(ltl_ctx, merlin_detector_cached, merlin_ds):
         assert acquisition.shape.nav == merlin_ds.shape.nav
 
     host, port = merlin_detector_cached
-    aq = ltl_ctx.prepare_acquisition('merlin', trigger=trigger, scan_size=(32, 32), host=host, port=port, drain=False)
+    aq = ltl_ctx.prepare_acquisition(
+        'merlin',
+        trigger=trigger,
+        scan_size=(32, 32),
+        host=host,
+        port=port,
+        drain=False
+    )
     udf = SumUDF()
 
     res = ltl_ctx.run_udf(dataset=aq, udf=udf)
@@ -175,7 +188,14 @@ def test_acquisition_memfd(ltl_ctx, merlin_detector_memfd, merlin_ds):
         assert acquisition.shape.nav == merlin_ds.shape.nav
 
     host, port = merlin_detector_memfd
-    aq = ltl_ctx.prepare_acquisition('merlin', trigger=trigger, scan_size=(32, 32), host=host, port=port, drain=False)
+    aq = ltl_ctx.prepare_acquisition(
+        'merlin',
+        trigger=trigger,
+        scan_size=(32, 32),
+        host=host,
+        port=port,
+        drain=False
+    )
     udf = SumUDF()
 
     res = ltl_ctx.run_udf(dataset=aq, udf=udf)
@@ -198,6 +218,7 @@ def test_acquisition_triggered_garbage(ltl_ctx, trigger_sim, garbage_sim, merlin
         print("Trigger connection:", trigger_sim)
         tr.connect()
         tr.trigger()
+
         def do_scan():
             '''
             Emulated blocking scan function using the Merlin simulator
@@ -208,7 +229,13 @@ def test_acquisition_triggered_garbage(ltl_ctx, trigger_sim, garbage_sim, merlin
         trig_res[0] = fut
         tr.close()
 
-    aq = ltl_ctx.prepare_acquisition('merlin', trigger=trigger, scan_size=(32, 32), host=sim_host, port=sim_port)
+    aq = ltl_ctx.prepare_acquisition(
+        'merlin',
+        trigger=trigger,
+        scan_size=(32, 32),
+        host=sim_host,
+        port=sim_port
+    )
     udf = SumUDF()
 
     res = ltl_ctx.run_udf(dataset=aq, udf=udf)
@@ -303,4 +330,3 @@ def test_control(merlin_control_sim, tmp_path):
         assert c.get("NUMFRAMESTOACQUIRE") == b'23'
         c.send_command_file(path)
         assert c.get("COUNTERDEPTH") == b'12'
-

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -1,3 +1,4 @@
+# flake8: NOQA:F401
 import libertem_live.api
 import libertem_live.detectors.base.acquisition
 import libertem_live.detectors.memory.acquisition


### PR DESCRIPTION
select.poll() doesn't always seem to be available on Windows

## Contributor Checklist:

* [x] I have added or updated my entry in [the creators.json file](https://github.com/LiberTEM/LiberTEM/blob/master/packaging/creators.json)
* [N/A] I have added [a changelog entry](https://github.com/LiberTEM/LiberTEM/tree/master/docs/source/changelog) for my contribution
* [N/A] I have added/updated documentation for all user-facing changes
* [N/A] I have added/updated test cases

## Reviewer Checklist:

* [x] `/azp run libertem.libertem-live-data` passed

<!--

Starting by submitting an incomplete pull request (PR) or draft PR is OK. You
can work on the checklist step by step by pushing additional commits into the
PR. Please indicate if you think some items may not be applicable.

You can have a look at [our contributing
docs](https://libertem.github.io/LiberTEM/contributing.html) for more
information on contributing to LiberTEM. Please feel free to ask for
clarification and help, for example in your PR description, with comments or in
our [Gitter channel](https://gitter.im/LiberTEM/Lobby).

Thank you for your contribution!

-->
