### PR TITLE
Support result iterator with real detector

### DIFF
--- a/docs/source/changelog/bugfix/iter.rst
+++ b/docs/source/changelog/bugfix/iter.rst
@@ -1,0 +1,4 @@
+[Bugfix] Support reading Merlin results as an iterator
+======================================================
+
+* Make sure the data socket stays connected while we consume from the result generator (:pr:`29`).

--- a/src/libertem_live/api.py
+++ b/src/libertem_live/api.py
@@ -76,4 +76,4 @@ class LiveContext(LiberTEM_Context):
 
     def run_udf_iter(self, dataset, udf, *args, **kwargs):
         with self._do_acquisition(dataset, udf):
-            return super().run_udf_iter(dataset=dataset, udf=udf, *args, **kwargs)
+            yield from super().run_udf_iter(dataset=dataset, udf=udf, *args, **kwargs)

--- a/tests/detectors/test_merlin.py
+++ b/tests/detectors/test_merlin.py
@@ -187,35 +187,6 @@ def test_acquisition_iter(ltl_ctx, merlin_detector_sim, merlin_ds):
     assert np.allclose(res.buffers[0]['intensity'], ref['intensity'])
 
 
-async def test_acquisition_async(ltl_ctx, merlin_detector_sim, merlin_ds):
-    triggered = triggered = np.array((False,))
-
-    def trigger(acquisition):
-        triggered[:] = True
-        assert acquisition.shape.nav == merlin_ds.shape.nav
-
-    host, port = merlin_detector_sim
-    aq = ltl_ctx.prepare_acquisition(
-        'merlin',
-        trigger=trigger,
-        nav_shape=(32, 32),
-        host=host,
-        port=port,
-        drain=False
-    )
-    udf = SumUDF()
-
-    res = await ltl_ctx.run_udf(dataset=aq, udf=udf, sync=False)
-    ref = ltl_ctx.run_udf(dataset=merlin_ds, udf=udf)
-
-    assert np.allclose(res['intensity'], ref['intensity'])
-
-    async for res in ltl_ctx.run_udf_iter(dataset=aq, udf=udf, sync=False):
-        pass
-
-    assert np.allclose(res.buffers[0]['intensity'], ref['intensity'])
-
-
 @pytest.mark.parametrize(
     # Test matching and mismatching shape
     'sig_shape', ((256, 256), (512, 512))

--- a/tests/detectors/test_merlin.py
+++ b/tests/detectors/test_merlin.py
@@ -161,6 +161,61 @@ def test_acquisition(ltl_ctx, merlin_detector_sim, merlin_ds):
     assert np.allclose(res['intensity'], ref['intensity'])
 
 
+def test_acquisition_iter(ltl_ctx, merlin_detector_sim, merlin_ds):
+    triggered = triggered = np.array((False,))
+
+    def trigger(acquisition):
+        triggered[:] = True
+        assert acquisition.shape.nav == merlin_ds.shape.nav
+
+    host, port = merlin_detector_sim
+    aq = ltl_ctx.prepare_acquisition(
+        'merlin',
+        trigger=trigger,
+        nav_shape=(32, 32),
+        host=host,
+        port=port,
+        drain=False
+    )
+    udf = SumUDF()
+
+    for res in ltl_ctx.run_udf_iter(dataset=aq, udf=udf, sync=True):
+        pass
+
+    ref = ltl_ctx.run_udf(dataset=merlin_ds, udf=udf)
+
+    assert np.allclose(res.buffers[0]['intensity'], ref['intensity'])
+
+
+async def test_acquisition_async(ltl_ctx, merlin_detector_sim, merlin_ds):
+    triggered = triggered = np.array((False,))
+
+    def trigger(acquisition):
+        triggered[:] = True
+        assert acquisition.shape.nav == merlin_ds.shape.nav
+
+    host, port = merlin_detector_sim
+    aq = ltl_ctx.prepare_acquisition(
+        'merlin',
+        trigger=trigger,
+        nav_shape=(32, 32),
+        host=host,
+        port=port,
+        drain=False
+    )
+    udf = SumUDF()
+
+    res = await ltl_ctx.run_udf(dataset=aq, udf=udf, sync=False)
+    ref = ltl_ctx.run_udf(dataset=merlin_ds, udf=udf)
+
+    assert np.allclose(res['intensity'], ref['intensity'])
+
+    async for res in ltl_ctx.run_udf_iter(dataset=aq, udf=udf, sync=False):
+        pass
+
+    assert np.allclose(res.buffers[0]['intensity'], ref['intensity'])
+
+
 @pytest.mark.parametrize(
     # Test matching and mismatching shape
     'sig_shape', ((256, 256), (512, 512))


### PR DESCRIPTION
If we just return the generator, we leave the connection context manager, i.e. the data socket is not connected when we actually consume items from the generator.

As a side note, that means we have to test all run methods (iter/result; sync/async) for each of the supported detectors: There might be "side effects" from the running method!

## Contributor Checklist:

* [x] I have added or updated my entry in [the creators.json file](https://github.com/LiberTEM/LiberTEM/blob/master/packaging/creators.json)
* [x] I have added [a changelog entry](https://github.com/LiberTEM/LiberTEM/tree/master/docs/source/changelog) for my contribution
* [N/A] I have added/updated documentation for all user-facing changes
* [x] I have added/updated test cases

## Reviewer Checklist:

* [ ] `/azp run libertem.libertem-live-data` passed

<!--

Starting by submitting an incomplete pull request (PR) or draft PR is OK. You
can work on the checklist step by step by pushing additional commits into the
PR. Please indicate if you think some items may not be applicable.

You can have a look at [our contributing
docs](https://libertem.github.io/LiberTEM/contributing.html) for more
information on contributing to LiberTEM. Please feel free to ask for
clarification and help, for example in your PR description, with comments or in
our [Gitter channel](https://gitter.im/LiberTEM/Lobby).

Thank you for your contribution!

-->
