### PR TITLE
Fix flakyness in `ReaderPoolImpl.get_result`

### DIFF
--- a/docs/source/changelog/bugfix/pool_flakyness.rst
+++ b/docs/source/changelog/bugfix/pool_flakyness.rst
@@ -1,0 +1,6 @@
+[Bugfix] Fix :code:`ReaderPool` flakyness
+=========================================
+
+* At the end of the acquisition, it could happen that
+  :code:`ReaderPoolImpl.get_result` returns too early, before the result queue
+  is drained (:pr:`31`)

--- a/src/libertem_live/detectors/merlin/acquisition.py
+++ b/src/libertem_live/detectors/merlin/acquisition.py
@@ -205,7 +205,7 @@ class MerlinLivePartition(Partition):
                 # )
                 with pool.get_result() as res_wrapped:
                     if res_wrapped is None:
-                        # ReaderThread was stopped
+                        # all `ReaderThread`s are stopped and the queue is empty:
                         return
                     frames_in_tile = res_wrapped.stop - res_wrapped.start
                     tile_shape = Shape(

--- a/tests/detectors/test_merlin.py
+++ b/tests/detectors/test_merlin.py
@@ -9,8 +9,10 @@ from contextlib import contextmanager
 
 import pytest
 import numpy as np
+from numpy.testing import assert_allclose
 
 from libertem.udf.sum import SumUDF
+from libertem.udf.sumsigudf import SumSigUDF
 
 from libertem_live.detectors.merlin import MerlinDataSource, MerlinControl
 from libertem_live.detectors.merlin.sim import (
@@ -151,14 +153,15 @@ def test_acquisition(ltl_ctx, merlin_detector_sim, merlin_ds):
         nav_shape=(32, 32),
         host=host,
         port=port,
-        drain=False
+        drain=False,
+        pool_size=16,
     )
     udf = SumUDF()
 
     res = ltl_ctx.run_udf(dataset=aq, udf=udf)
     ref = ltl_ctx.run_udf(dataset=merlin_ds, udf=udf)
 
-    assert np.allclose(res['intensity'], ref['intensity'])
+    assert_allclose(res['intensity'], ref['intensity'])
 
 
 def test_acquisition_iter(ltl_ctx, merlin_detector_sim, merlin_ds):
@@ -175,7 +178,8 @@ def test_acquisition_iter(ltl_ctx, merlin_detector_sim, merlin_ds):
         nav_shape=(32, 32),
         host=host,
         port=port,
-        drain=False
+        drain=False,
+        pool_size=16,
     )
     udf = SumUDF()
 
@@ -184,7 +188,7 @@ def test_acquisition_iter(ltl_ctx, merlin_detector_sim, merlin_ds):
 
     ref = ltl_ctx.run_udf(dataset=merlin_ds, udf=udf)
 
-    assert np.allclose(res.buffers[0]['intensity'], ref['intensity'])
+    assert_allclose(res.buffers[0]['intensity'], ref['intensity'])
 
 
 @pytest.mark.asyncio
@@ -202,19 +206,20 @@ async def test_acquisition_async(ltl_ctx, merlin_detector_sim, merlin_ds):
         nav_shape=(32, 32),
         host=host,
         port=port,
-        drain=False
+        drain=False,
+        pool_size=16,
     )
     udf = SumUDF()
 
     res = await ltl_ctx.run_udf(dataset=aq, udf=udf, sync=False)
     ref = ltl_ctx.run_udf(dataset=merlin_ds, udf=udf)
 
-    assert np.allclose(res['intensity'], ref['intensity'])
+    assert_allclose(res['intensity'], ref['intensity'])
 
     async for res in ltl_ctx.run_udf_iter(dataset=aq, udf=udf, sync=False):
         pass
 
-    assert np.allclose(res.buffers[0]['intensity'], ref['intensity'])
+    assert_allclose(res.buffers[0]['intensity'], ref['intensity'])
 
 
 @pytest.mark.parametrize(
@@ -236,7 +241,8 @@ def test_acquisition_shape(ltl_ctx, merlin_detector_sim, merlin_ds, sig_shape):
         sig_shape=sig_shape,
         host=host,
         port=port,
-        drain=False
+        drain=False,
+        pool_size=16,
     )
 
     try:
@@ -245,7 +251,7 @@ def test_acquisition_shape(ltl_ctx, merlin_detector_sim, merlin_ds, sig_shape):
         res = ltl_ctx.run_udf(dataset=aq, udf=udf)
         ref = ltl_ctx.run_udf(dataset=merlin_ds, udf=udf)
 
-        assert np.allclose(res['intensity'], ref['intensity'])
+        assert_allclose(res['intensity'], ref['intensity'])
         assert sig_shape == tuple(merlin_ds.shape.sig)
     except ValueError as e:
         assert sig_shape != tuple(merlin_ds.shape.sig)
@@ -266,14 +272,15 @@ def test_acquisition_cached(ltl_ctx, merlin_detector_cached, merlin_ds):
         nav_shape=(32, 32),
         host=host,
         port=port,
-        drain=False
+        drain=False,
+        pool_size=16,
     )
     udf = SumUDF()
 
     res = ltl_ctx.run_udf(dataset=aq, udf=udf)
     ref = ltl_ctx.run_udf(dataset=merlin_ds, udf=udf)
 
-    assert np.allclose(res['intensity'], ref['intensity'])
+    assert_allclose(res['intensity'], ref['intensity'])
 
 
 @pytest.mark.skipif(platform.system() != 'Linux',
@@ -292,14 +299,15 @@ def test_acquisition_memfd(ltl_ctx, merlin_detector_memfd, merlin_ds):
         nav_shape=(32, 32),
         host=host,
         port=port,
-        drain=False
+        drain=False,
+        pool_size=16,
     )
     udf = SumUDF()
 
     res = ltl_ctx.run_udf(dataset=aq, udf=udf)
     ref = ltl_ctx.run_udf(dataset=merlin_ds, udf=udf)
 
-    assert np.allclose(res['intensity'], ref['intensity'])
+    assert_allclose(res['intensity'], ref['intensity'])
 
 
 def test_acquisition_triggered_garbage(ltl_ctx, trigger_sim, garbage_sim, merlin_ds):
@@ -332,7 +340,8 @@ def test_acquisition_triggered_garbage(ltl_ctx, trigger_sim, garbage_sim, merlin
         trigger=trigger,
         nav_shape=(32, 32),
         host=sim_host,
-        port=sim_port
+        port=sim_port,
+        pool_size=16,
     )
     udf = SumUDF()
 
@@ -341,7 +350,7 @@ def test_acquisition_triggered_garbage(ltl_ctx, trigger_sim, garbage_sim, merlin
 
     ref = ltl_ctx.run_udf(dataset=merlin_ds, udf=udf)
 
-    assert np.allclose(res['intensity'], ref['intensity'])
+    assert_allclose(res['intensity'], ref['intensity'])
 
 
 def test_acquisition_triggered_control(ltl_ctx, merlin_control_sim, garbage_sim, merlin_ds):
@@ -371,7 +380,8 @@ def test_acquisition_triggered_control(ltl_ctx, merlin_control_sim, garbage_sim,
         trigger=trigger,
         nav_shape=(32, 32),
         host=sim_host,
-        port=sim_port
+        port=sim_port,
+        pool_size=16,
     )
     udf = SumUDF()
 
@@ -380,7 +390,7 @@ def test_acquisition_triggered_control(ltl_ctx, merlin_control_sim, garbage_sim,
 
     ref = ltl_ctx.run_udf(dataset=merlin_ds, udf=udf)
 
-    assert np.allclose(res['intensity'], ref['intensity'])
+    assert_allclose(res['intensity'], ref['intensity'])
 
 
 @pytest.mark.parametrize(
@@ -392,7 +402,7 @@ def test_acquisition_triggered_control(ltl_ctx, merlin_control_sim, garbage_sim,
 )
 def test_datasource(ltl_ctx, merlin_detector_sim, merlin_ds, inline, sig_shape):
     print("Merlin sim:", merlin_detector_sim)
-    source = MerlinDataSource(*merlin_detector_sim, sig_shape=sig_shape)
+    source = MerlinDataSource(*merlin_detector_sim, sig_shape=sig_shape, pool_size=16)
 
     res = np.zeros(merlin_ds.shape.sig)
     try:
@@ -405,11 +415,23 @@ def test_datasource(ltl_ctx, merlin_detector_sim, merlin_ds, inline, sig_shape):
                     res += chunk.buf.sum(axis=0)
         udf = SumUDF()
         ref = ltl_ctx.run_udf(dataset=merlin_ds, udf=udf)
-        assert np.allclose(res, ref['intensity'])
+        assert_allclose(res, ref['intensity'])
         assert (sig_shape is None) or (sig_shape == tuple(merlin_ds.shape.sig))
     except ValueError as e:
         assert sig_shape != tuple(merlin_ds.shape.sig)
         assert 'received "image_size" header' in e.args[0]
+
+
+def test_datasource_nav(ltl_ctx, merlin_detector_sim, merlin_ds):
+    source = MerlinDataSource(*merlin_detector_sim, pool_size=16)
+
+    res = np.zeros(merlin_ds.shape.nav).reshape((-1,))
+    with source:
+        for chunk in source.stream(num_frames=merlin_ds.shape.nav.size):
+            res[chunk.start:chunk.stop] = chunk.buf.sum(axis=(-1, -2))
+    udf = SumSigUDF()
+    ref = ltl_ctx.run_udf(dataset=merlin_ds, udf=udf)
+    assert_allclose(res.reshape(merlin_ds.shape.nav), ref['intensity'])
 
 
 class BadServer(ServerThreadMixin, threading.Thread):


### PR DESCRIPTION
This was mostly (only?) triggered by `MerlinDataSource.stream`, in the testcase `test_datasource`.

The conditions for this issue are as follows:

- Our `ReaderThread`s have read most of the data from the socket, and we
  are at the end of the stream
- One of the reader threads enters `read_multi_frames`, sees that we are
  done (because the number of frames to read is 0), and returns `True`.
  The thread exits as it doesn't have any work left. At this point, the
  result queue is also still empty.
- Another reader thread is still decoding their stack of frames. When it
  is done, it adds its result to the result queue and also exits.
- From the main thread, `ReaderPoolImpl` checks the status of the reader
  threads. This is where the problem happened: it stopped processing
  even when there were still reader threads running, and possibly items
  in the queue or to be added to the queue in the near future.

This is addressed by properly checking that _all_ threads have exited,
and the output queue is empty.

The test cases have also been adapted to use a larger number of threads
for reading, which increases the likelihood of hitting this problem.

## Contributor Checklist:

* [x] I have added or updated my entry in [the creators.json file](https://github.com/LiberTEM/LiberTEM/blob/master/packaging/creators.json)
* [x] I have added [a changelog entry](https://github.com/LiberTEM/LiberTEM/tree/master/docs/source/changelog) for my contribution
* [N/A] I have added/updated documentation for all user-facing changes
* [x] I have added/updated test cases

## Reviewer Checklist:

* [ ] `/azp run libertem.libertem-live-data` passed

<!--

Starting by submitting an incomplete pull request (PR) or draft PR is OK. You
can work on the checklist step by step by pushing additional commits into the
PR. Please indicate if you think some items may not be applicable.

You can have a look at [our contributing
docs](https://libertem.github.io/LiberTEM/contributing.html) for more
information on contributing to LiberTEM. Please feel free to ask for
clarification and help, for example in your PR description, with comments or in
our [Gitter channel](https://gitter.im/LiberTEM/Lobby).

Thank you for your contribution!

-->
