### PR TITLE
LiberTEM v0.9 compatibility

### DIFF
--- a/azure-pipelines-data.yml
+++ b/azure-pipelines-data.yml
@@ -229,12 +229,6 @@ stages:
           path: $(PIP_CACHE_DIR)
         displayName: 'cache pip packages'
 
-      - task: Cache@2
-        inputs:
-          key: 'tox_lint | "$(Agent.OS)" | docs_requirements.txt | test_requirements.txt | setup.py | "$(TOXENV)"'
-          path: $(tox_dir)
-        displayName: 'cache tox environment'
-
       - bash: apt install -y pandoc
         displayName: install required debian packages
       - bash: pip install -U tox

--- a/azure-pipelines-data.yml
+++ b/azure-pipelines-data.yml
@@ -235,7 +235,7 @@ stages:
           path: $(tox_dir)
         displayName: 'cache tox environment'
 
-      - bash: sudo apt install -y pandoc
+      - bash: apt install -y pandoc
         displayName: install required debian packages
       - bash: pip install -U tox
         displayName: 'install requirements'
@@ -251,7 +251,7 @@ stages:
         displayName: 'Use Python 3.9'
         inputs:
           versionSpec: '3.9'
-      - bash: sudo apt install -y pandoc
+      - bash: apt install -y pandoc
         displayName: 'install required debian packages'
 
       - task: Cache@2

--- a/azure-pipelines-data.yml
+++ b/azure-pipelines-data.yml
@@ -26,15 +26,6 @@ stages:
         inputs:
           versionSpec: '3.9'
 
-      - task: Cache@2
-        inputs:
-          key: 'python | "$(Agent.OS)" | test_requirements.txt'
-          restoreKeys: |
-            python | "$(Agent.OS)"
-            python
-          path: $(PIP_CACHE_DIR)
-        displayName: 'cache pip packages'
-
       - bash: python3.9 -m venv venv
         displayName: 'create venv'
 
@@ -89,15 +80,6 @@ stages:
         inputs:
           versionSpec: '$(python.version)'
 
-      - task: Cache@2
-        inputs:
-          key: 'python | "$(Agent.OS)" | test_requirements.txt'
-          restoreKeys: |
-            python | "$(Agent.OS)"
-            python
-          path: $(PIP_CACHE_DIR)
-        displayName: 'cache pip packages'
-
       - bash: python3.9 -m venv venv
         displayName: 'create venv'
 
@@ -146,16 +128,6 @@ stages:
         inputs:
           versionSpec: '$(python.version)'
 
-      - task: Cache@2
-        inputs:
-          key: 'python | "$(Agent.OS)" | "$(python.version)" | setup.py | test_requirements.txt'
-          restoreKeys: |
-            python | "$(Agent.OS)" | "$(python.version)"
-            python | "$(Agent.OS)"
-            python
-          path: $(PIP_CACHE_DIR)
-        displayName: 'cache pip packages'
-
       - bash: pip install -U tox
         displayName: 'install requirements'
 
@@ -180,16 +152,6 @@ stages:
         displayName: 'Use Python 3.9'
         inputs:
           versionSpec: '3.9'
-
-      - task: Cache@2
-        inputs:
-          key: 'python | "$(Agent.OS)" | "3.9" | setup.py | test_requirements.txt'
-          restoreKeys: |
-            python | "$(Agent.OS)" | "3.9"
-            python | "$(Agent.OS)"
-            python
-          path: $(PIP_CACHE_DIR)
-        displayName: 'cache pip packages'
 
       - bash: pip install -U tox
         displayName: 'install requirements'
@@ -220,15 +182,6 @@ stages:
         inputs:
           versionSpec: '3.9'
 
-      - task: Cache@2
-        inputs:
-          key: 'lint | "$(Agent.OS)"'
-          restoreKeys: |
-            lint | "$(Agent.OS)"
-            lint
-          path: $(PIP_CACHE_DIR)
-        displayName: 'cache pip packages'
-
       - bash: apt install -y pandoc
         displayName: install required debian packages
       - bash: pip install -U tox
@@ -247,15 +200,6 @@ stages:
           versionSpec: '3.9'
       - bash: apt install -y pandoc
         displayName: 'install required debian packages'
-
-      - task: Cache@2
-        inputs:
-          key: 'deploy_docs | "$(Agent.OS)" | setup.py | docs_requirements.txt'
-          restoreKeys: |
-            deploy_docs | "$(Agent.OS)"
-            deploy_docs
-          path: $(PIP_CACHE_DIR)
-        displayName: 'cache pip packages'
 
       - bash: pip install -U tox && pip install -r scripts/requirements.txt
         displayName: 'install requirements'
@@ -285,14 +229,6 @@ stages:
         displayName: 'Use Python 3.9'
         inputs:
           versionSpec: '3.9'
-      - task: Cache@2
-        inputs:
-          key: 'deploy | "$(Agent.OS)" | scripts/requirements.txt'
-          restoreKeys: |
-            deploy | "$(Agent.OS)"
-            deploy
-          path: $(PIP_CACHE_DIR)
-        displayName: 'cache pip packages'
       - bash: pip install -U tox && pip install -r scripts/requirements.txt
         displayName: 'install requirements'
       - bash: python scripts/release --verbose upload --no-dry-run

--- a/azure-pipelines-data.yml
+++ b/azure-pipelines-data.yml
@@ -123,8 +123,7 @@ stages:
           reportDirectory: '$(System.DefaultWorkingDirectory)/**/htmlcov'
 
     - job: linux_tests
-      pool:
-        vmImage: 'ubuntu-latest'
+      pool: DataAccess
       strategy:
         matrix:
           Python36:
@@ -173,8 +172,7 @@ stages:
           testRunTitle: 'Publish test results for Python $(python.version)'
 
     - job: numba_coverage
-      pool:
-        vmImage: 'ubuntu-latest'
+      pool: DataAccess
       variables:
         TOXENV: 'numba_coverage'
       steps:
@@ -209,8 +207,7 @@ stages:
           testRunTitle: 'Publish test results for numba coverage on Python 3.9'
 
     - job: lint
-      pool:
-        vmImage: 'ubuntu-latest'
+      pool: DataAccess
       strategy:
         matrix:
           docs-check:
@@ -248,8 +245,7 @@ stages:
   - stage: deploy
     jobs:
     - job: deploy_docs
-      pool:
-        vmImage: 'ubuntu-latest'
+      pool: DataAccess
       steps:
       - task: UsePythonVersion@0
         displayName: 'Use Python 3.9'
@@ -289,8 +285,7 @@ stages:
             and(not(eq(variables['Build.Reason'], 'PullRequest')),
                 eq(variables['Build.SourceBranch'], 'refs/heads/master'))
     - job: make_upload_packages
-      pool:
-        vmImage: 'ubuntu-latest'
+      pool: DataAccess
       steps:
       - task: UsePythonVersion@0
         displayName: 'Use Python 3.9'

--- a/azure-pipelines-data.yml
+++ b/azure-pipelines-data.yml
@@ -2,8 +2,13 @@ trigger:
 - master
 
 variables:
+  - group: Packaging
   - name: PIP_CACHE_DIR
     value: $(Pipeline.Workspace)/.pip
+  - name: npm_config_cache
+    value: $(Pipeline.Workspace)/.npm
+  - name: tox_dir
+    value: $(Build.Repository.LocalPath)/.tox
 
 stages:
   - stage: test
@@ -116,3 +121,198 @@ stages:
           codeCoverageTool: Cobertura
           summaryFileLocation: '$(System.DefaultWorkingDirectory)/**/coverage.xml'
           reportDirectory: '$(System.DefaultWorkingDirectory)/**/htmlcov'
+
+    - job: linux_tests
+      pool:
+        vmImage: 'ubuntu-latest'
+      strategy:
+        matrix:
+          Python36:
+            python.version: '3.6'
+            TOXENV: 'py36'
+          Python37:
+            python.version: '3.7'
+            TOXENV: 'py37'
+          Python38:
+            python.version: '3.8'
+            TOXENV: 'py38'
+          Python39:
+            python.version: '3.9'
+            TOXENV: 'py39'
+      variables:
+        TOXENV: '$(TOXENV)'
+      steps:
+      - task: UsePythonVersion@0
+        displayName: 'Use Python $(python.version)'
+        inputs:
+          versionSpec: '$(python.version)'
+
+      - task: Cache@2
+        inputs:
+          key: 'python | "$(Agent.OS)" | "$(python.version)" | setup.py | test_requirements.txt'
+          restoreKeys: |
+            python | "$(Agent.OS)" | "$(python.version)"
+            python | "$(Agent.OS)"
+            python
+          path: $(PIP_CACHE_DIR)
+        displayName: 'cache pip packages'
+
+      - bash: pip install -U tox
+        displayName: 'install requirements'
+
+      - bash: tox
+        displayName: 'Run tox tests $(TOXENV) $(Agent.OS)'
+
+      - bash: bash <(curl -s https://codecov.io/bash) -f coverage.xml
+        displayName: 'Submit coverage to codecov.io'
+
+      - task: PublishTestResults@2
+        condition: succeededOrFailed()
+        inputs:
+          testResultsFiles: 'junit.xml'
+          testRunTitle: 'Publish test results for Python $(python.version)'
+
+    - job: numba_coverage
+      pool:
+        vmImage: 'ubuntu-latest'
+      variables:
+        TOXENV: 'numba_coverage'
+      steps:
+      - task: UsePythonVersion@0
+        displayName: 'Use Python 3.9'
+        inputs:
+          versionSpec: '3.9'
+
+      - task: Cache@2
+        inputs:
+          key: 'python | "$(Agent.OS)" | "3.9" | setup.py | test_requirements.txt'
+          restoreKeys: |
+            python | "$(Agent.OS)" | "3.9"
+            python | "$(Agent.OS)"
+            python
+          path: $(PIP_CACHE_DIR)
+        displayName: 'cache pip packages'
+
+      - bash: pip install -U tox
+        displayName: 'install requirements'
+
+      - bash: tox
+        displayName: 'Run tox tests $(TOXENV) $(Agent.OS)'
+
+      - bash: bash <(curl -s https://codecov.io/bash) -f coverage.xml
+        displayName: 'Submit coverage to codecov.io'
+
+      - task: PublishTestResults@2
+        condition: succeededOrFailed()
+        inputs:
+          testResultsFiles: 'junit.xml'
+          testRunTitle: 'Publish test results for numba coverage on Python 3.9'
+
+    - job: lint
+      pool:
+        vmImage: 'ubuntu-latest'
+      strategy:
+        matrix:
+          docs-check:
+            TOXENV: 'docs-check'
+      variables:
+        TOXENV: '$(TOXENV)'
+      steps:
+      - task: UsePythonVersion@0
+        displayName: 'Use Python 3.9'
+        inputs:
+          versionSpec: '3.9'
+
+      - task: Cache@2
+        inputs:
+          key: 'lint | "$(Agent.OS)"'
+          restoreKeys: |
+            lint | "$(Agent.OS)"
+            lint
+          path: $(PIP_CACHE_DIR)
+        displayName: 'cache pip packages'
+
+      - task: Cache@2
+        inputs:
+          key: 'tox_lint | "$(Agent.OS)" | docs_requirements.txt | test_requirements.txt | setup.py | "$(TOXENV)"'
+          path: $(tox_dir)
+        displayName: 'cache tox environment'
+
+      - bash: sudo apt install -y pandoc
+        displayName: install required debian packages
+      - bash: pip install -U tox
+        displayName: 'install requirements'
+      - bash: tox
+        displayName: 'Run tox lint $(TOXENV) $(Agent.OS)'
+
+  - stage: deploy
+    jobs:
+    - job: deploy_docs
+      pool:
+        vmImage: 'ubuntu-latest'
+      steps:
+      - task: UsePythonVersion@0
+        displayName: 'Use Python 3.9'
+        inputs:
+          versionSpec: '3.9'
+      - bash: sudo apt install -y pandoc
+        displayName: 'install required debian packages'
+
+      - task: Cache@2
+        inputs:
+          key: 'deploy_docs | "$(Agent.OS)" | setup.py | docs_requirements.txt'
+          restoreKeys: |
+            deploy_docs | "$(Agent.OS)"
+            deploy_docs
+          path: $(PIP_CACHE_DIR)
+        displayName: 'cache pip packages'
+
+      - bash: pip install -U tox && pip install -r scripts/requirements.txt
+        displayName: 'install requirements'
+
+      - bash: tox -e docs-build-ci
+        displayName: 'build docs'
+
+      - task: DownloadSecureFile@1
+        inputs:
+          secureFile: deploy_key
+        displayName: 'Get the deploy key'
+
+      - script: |
+          mkdir ~/.ssh && mv $DOWNLOADSECUREFILE_SECUREFILEPATH ~/.ssh/id_rsa
+          chmod 700 ~/.ssh && chmod 600 ~/.ssh/id_rsa
+          ssh-keyscan -t rsa github.com >> ~/.ssh/known_hosts
+
+      - bash: ./scripts/deploy_docs docs/build/html/
+        displayName: 'deploy docs'
+        condition: |
+            and(not(eq(variables['Build.Reason'], 'PullRequest')),
+                eq(variables['Build.SourceBranch'], 'refs/heads/master'))
+    - job: make_upload_packages
+      pool:
+        vmImage: 'ubuntu-latest'
+      steps:
+      - task: UsePythonVersion@0
+        displayName: 'Use Python 3.9'
+        inputs:
+          versionSpec: '3.9'
+      - task: Cache@2
+        inputs:
+          key: 'deploy | "$(Agent.OS)" | scripts/requirements.txt'
+          restoreKeys: |
+            deploy | "$(Agent.OS)"
+            deploy
+          path: $(PIP_CACHE_DIR)
+        displayName: 'cache pip packages'
+      - bash: pip install -U tox && pip install -r scripts/requirements.txt
+        displayName: 'install requirements'
+      - bash: python scripts/release --verbose upload --no-dry-run
+        displayName: 'Upload packages / release'
+        env:
+          LT_RELEASE_UPLOAD_PYPI_PASSWORD: $(LT_RELEASE_UPLOAD_PYPI_PASSWORD)
+          LT_RELEASE_UPLOAD_PYPI_TEST_PASSWORD: $(LT_RELEASE_UPLOAD_PYPI_TEST_PASSWORD)
+          LT_RELEASE_UPLOAD_TOKEN: $(LT_RELEASE_UPLOAD_TOKEN)
+          LT_RELEASE_UPLOAD_ZENODO_SANDBOX_TOKEN: $(LT_RELEASE_UPLOAD_ZENODO_SANDBOX_TOKEN)
+          LT_RELEASE_UPLOAD_ZENODO_TOKEN: $(LT_RELEASE_UPLOAD_ZENODO_TOKEN)
+          LT_RELEASE_UPLOAD_ZENODO_SANDBOX_PARENT: $(LT_RELEASE_UPLOAD_ZENODO_SANDBOX_PARENT)
+          LT_RELEASE_UPLOAD_ZENODO_PARENT: $(LT_RELEASE_UPLOAD_ZENODO_PARENT)

--- a/docs_requirements.txt
+++ b/docs_requirements.txt
@@ -1,6 +1,4 @@
-# FIXME remove Sphinx version constraint as
-# soon as https://github.com/sphinx-doc/sphinx/issues/8880 is released
-sphinx>1.4,<3.5
+sphinx
 sphinx-autobuild
 sphinxcontrib-bibtex>=2
 sphinx-issues

--- a/setup.py
+++ b/setup.py
@@ -78,7 +78,7 @@ setup(
     zip_safe=False,
     python_requires='>=3.6',
     install_requires=[
-        "libertem>=0.7.0",
+        "libertem>=0.9.0",
         "numpy",
         "click",
         "tqdm",

--- a/src/libertem_live/detectors/merlin/acquisition.py
+++ b/src/libertem_live/detectors/merlin/acquisition.py
@@ -148,7 +148,8 @@ class MerlinAcquisition(AcquisitionMixin, DataSet):
         header = self.source.socket.get_acquisition_header()
         frame_header = self.source.socket.get_first_frame_header()
 
-        self.source.validate_get_sig_shape(frame_header, self._sig_shape)
+        if frame_header is not None:
+            self.source.validate_get_sig_shape(frame_header, self._sig_shape)
 
         slices = BasePartition.make_slices(self.shape, num_partitions)
         for part_slice, start, stop in slices:

--- a/src/libertem_live/detectors/merlin/data.py
+++ b/src/libertem_live/detectors/merlin/data.py
@@ -103,6 +103,7 @@ class MerlinDataSocket:
         self._timeout = timeout
         self._socket = None
         self._acquisition_header = None
+        self._first_frame_header = None
         self._is_connected = False
         self._read_lock = threading.Lock()
         self._frame_counter = 0

--- a/src/libertem_live/detectors/merlin/sim.py
+++ b/src/libertem_live/detectors/merlin/sim.py
@@ -243,14 +243,12 @@ class DataSocketSimulator:
         full_frame_size : int
             Size of header plus frame in bytes
         """
-        # backwards-compat. for LiberTEM v0.8
-        if hasattr(fh, "_path"):
-            path = fh._path
-        elif hasattr(fh, "path"):
-            path = fh.path
+        if hasattr(fh, '_file'):
+            if fh._file is None:
+                fh.open()
+            f = fh._file
         else:
-            raise RuntimeError(f"unknown file object {fh}")
-        f = open(path, "rb")
+            f = open(fh._path, 'rb')
         fileno = f.fileno()
         if fileno not in self._mmaps:
             self._mmaps[fileno] = raw_mmap = mmap.mmap(

--- a/tests/detectors/merlin/test_merlin.py
+++ b/tests/detectors/merlin/test_merlin.py
@@ -174,6 +174,30 @@ def test_acquisition(ltl_ctx, merlin_detector_sim, merlin_ds):
     assert_allclose(res['intensity'], ref['intensity'])
 
 
+def test_acquisition_dry_run(ltl_ctx, merlin_detector_sim, merlin_ds):
+    triggered = triggered = np.array((False,))
+
+    def trigger(acquisition):
+        triggered[:] = True
+        assert acquisition.shape.nav == merlin_ds.shape.nav
+
+    host, port = merlin_detector_sim
+    aq = ltl_ctx.prepare_acquisition(
+        'merlin',
+        trigger=trigger,
+        nav_shape=(32, 32),
+        host=host,
+        port=port,
+        drain=False,
+        pool_size=16,
+    )
+    udf = SumUDF()
+
+    runner_cls = ltl_ctx.executor.get_udf_runner()
+    runner_cls.dry_run([udf], aq, None)
+    ltl_ctx.run_udf(dataset=aq, udf=udf)
+
+
 def test_acquisition_iter(ltl_ctx, merlin_detector_sim, merlin_ds):
     triggered = triggered = np.array((False,))
 

--- a/tests/detectors/merlin/test_merlin.py
+++ b/tests/detectors/merlin/test_merlin.py
@@ -138,6 +138,16 @@ def merlin_ds(ltl_ctx):
     return ltl_ctx.load('MIB', path=MIB_TESTDATA_PATH, nav_shape=(32, 32))
 
 
+@pytest.mark.parametrize(
+    'sim_cls', (CachedDataSocketSim, MemfdSocketSim)
+)
+def test_socket_simulator_get_chunks(sim_cls):
+    sim = sim_cls(path=MIB_TESTDATA_PATH, nav_shape=(32, 32))
+    sim.open()
+    for chunk in sim.get_chunks():
+        pass
+
+
 @pytest.mark.with_numba  # Get coverage for decoders
 def test_acquisition(ltl_ctx, merlin_detector_sim, merlin_ds):
     triggered = triggered = np.array((False,))


### PR DESCRIPTION
Because we are currently still using LiberTEM internal APIs in LiberTEM-live, we need to keep them in sync.

This bumps the LiberTEM dependency to v0.9, too - we could work around this with some effort, but it would make the code a bit less readable (i.e. duplication of tileshape  negotiation related code in dataset and partition classes)

# TODO

- [N/A] Make sure this is all the code changes needed - might need additional tests!
- [x] Fix dry run scenario
- [x] Update pipelines to use on-prem agent

## Contributor Checklist:

* [ ] I have added or updated my entry in [the creators.json file](https://github.com/LiberTEM/LiberTEM/blob/master/packaging/creators.json)
* [ ] I have added [a changelog entry](https://github.com/LiberTEM/LiberTEM/tree/master/docs/source/changelog) for my contribution
* [ ] I have added/updated documentation for all user-facing changes
* [ ] I have added/updated test cases

## Reviewer Checklist:

* [x] `/azp run libertem.libertem-live-data` passed

<!--

Starting by submitting an incomplete pull request (PR) or draft PR is OK. You
can work on the checklist step by step by pushing additional commits into the
PR. Please indicate if you think some items may not be applicable.

You can have a look at [our contributing
docs](https://libertem.github.io/LiberTEM/contributing.html) for more
information on contributing to LiberTEM. Please feel free to ask for
clarification and help, for example in your PR description, with comments or in
our [Gitter channel](https://gitter.im/LiberTEM/Lobby).

Thank you for your contribution!

-->
