### PR TITLE
Fix issues with tile shape adjustment for corrections

### DIFF
--- a/src/libertem_live/detectors/dectris/acquisition.py
+++ b/src/libertem_live/detectors/dectris/acquisition.py
@@ -397,7 +397,7 @@ class DectrisAcquisition(AcquisitionMixin, DataSet):
         return 12*np.prod(self.meta.shape.sig)*8
 
     def get_base_shape(self, roi):
-        return (1, 1, self.meta.shape.sig[-1])
+        return (1, *self.meta.shape.sig)
 
     @property
     def acquisition_state(self):


### PR DESCRIPTION
* Already set base shape to full frames instead of forcing it after with adjust_tileshape(), meaning it doesn't hit the issue fixed in https://github.com/LiberTEM/LiberTEM/pull/1355
* Include correction in test case that would trigger the issue

## Contributor Checklist:

* [x] I have added or updated my entry in [the creators.json file](https://github.com/LiberTEM/LiberTEM/blob/master/packaging/creators.json)
* [N/A] I have added [a changelog entry](https://github.com/LiberTEM/LiberTEM/tree/master/docs/source/changelog) for my contribution
* [N/A] I have added/updated documentation for all user-facing changes
* [x] I have added/updated test cases

## Reviewer Checklist:

* [x] `/azp run libertem.libertem-live-data` passed

<!--

Starting by submitting an incomplete pull request (PR) or draft PR is OK. You
can work on the checklist step by step by pushing additional commits into the
PR. Please indicate if you think some items may not be applicable.

You can have a look at [our contributing
docs](https://libertem.github.io/LiberTEM/contributing.html) for more
information on contributing to LiberTEM. Please feel free to ask for
clarification and help, for example in your PR description, with comments or in
our [Gitter channel](https://gitter.im/LiberTEM/Lobby).

Thank you for your contribution!

-->
