### PR TITLE
Manual trigger for Merlin sim

### DIFF
--- a/src/libertem_live/detectors/merlin/sim.py
+++ b/src/libertem_live/detectors/merlin/sim.py
@@ -816,7 +816,8 @@ class CameraSim:
 )
 @click.option('--max-runs', type=int, default=-1)
 def main(path, nav_shape, continuous,
-        host, data_port, control_port, trigger_port, wait_trigger, manual_trigger, garbage, cached, max_runs):
+        host, data_port, control_port, trigger_port, wait_trigger,
+        manual_trigger, garbage, cached, max_runs):
     camera_sim = CameraSim(
         path=path, nav_shape=nav_shape, continuous=continuous,
         host=host, data_port=data_port, control_port=control_port, trigger_port=trigger_port,


### PR DESCRIPTION
From issue #72 adding a `--manual-trigger` option to the Merlin simulator. Needs a similar update for the Dectris simulator.

## Contributor Checklist:

* [ ] I have added or updated my entry in [the creators.json file](https://github.com/LiberTEM/LiberTEM/blob/master/packaging/creators.json)
* [ ] I have added [a changelog entry](https://github.com/LiberTEM/LiberTEM/tree/master/docs/source/changelog) for my contribution
* [ ] I have added/updated documentation for all user-facing changes
* [ ] I have added/updated test cases

## Reviewer Checklist:

* [ ] `/azp run libertem.libertem-live-data` passed