### PR TITLE
Add mock Merlin MIB DataSet and simulator tests

### DIFF
--- a/docs/source/changelog/misc/mock_merlin_ds.rst
+++ b/docs/source/changelog/misc/mock_merlin_ds.rst
@@ -1,0 +1,6 @@
+[Misc] Mock dataset for Merlin testing
+======================================
+
+A mock Merlin Medipix dataset is now generated
+during testing to enable better coverage when
+test data is not available. (:pr:`103`)

--- a/packaging/creators.json
+++ b/packaging/creators.json
@@ -13,7 +13,7 @@
         "affiliation": "CEA-Leti",
         "github": "matbryan52",
         "orcid": "0000-0001-9134-384X",
-        "contribution": "Manual triggering for Merlin simulator, Packaging"
+        "contribution": "Manual triggering for Merlin simulator, packaging, testing"
     },
     {
         "displayname": "Volker Pilipp",

--- a/tests/detectors/merlin/conftest.py
+++ b/tests/detectors/merlin/conftest.py
@@ -2,8 +2,12 @@ import os
 import platform
 
 import pytest
+import pathlib
+import numpy as np
 
 from utils import get_testdata_path, run_camera_sim
+import libertem.api as lt
+from libertem.common.shape import Shape
 from libertem_live.detectors.merlin.sim import (
     CameraSim
 )
@@ -233,3 +237,110 @@ def merlin_detector_memfd(merlin_detector_memfd_threads):
     Host, port tuple of the untriggered default simulator with memfd cache
     '''
     return merlin_detector_memfd_threads.server_t.sockname
+
+
+def get_header_string(num_frames, counter_depth):
+    return fr"""HDR,
+Counter Depth (number):	{counter_depth}
+Frames in Acquisition (Number):	{num_frames}
+Frames per Trigger (Number):	{num_frames}
+End	                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                               """  # noqa: W291,E501
+
+
+def get_frame_header_encoded(sig_size, counter_depth, header_size=None):
+    if header_size is None:
+        header_size = 0
+    if header_size > 10000:
+        raise ValueError('Cannot encode header with size more than 5 digits')
+    if sig_size > 1000:
+        raise ValueError('Cannot encode frame with size more than 4 digits')
+    encoded = fr"""MQ1,000001,{header_size:0>5d},01,{sig_size:0>4d},{sig_size:0>4d},U08,   1x1,01,2020-05-18 16:51:49.971626,0.000555,0,0,0,1.200000E+2,5.110000E+2,0.000000E+0,0.000000E+0,0.000000E+0,0.000000E+0,0.000000E+0,0.000000E+0,3RX,175,511,000,000,000,000,000,000,125,255,125,125,100,100,082,100,087,030,128,004,255,129,128,176,168,511,511,MQ1A,2020-05-18T14:51:49.971626178Z,555000ns,{counter_depth}
+""".encode("ascii")  # noqa
+    if header_size == 0:
+        return get_frame_header_encoded(sig_size, counter_depth, header_size=len(encoded))
+    return encoded
+
+
+@pytest.fixture(scope='module')
+def mock_mib_ds(tmpdir_factory):
+    datadir = tmpdir_factory.mktemp('mock_mib_dataset')
+    datadir = pathlib.Path(datadir)
+
+    shape = Shape((8, 8, 16, 16), sig_dims=2)
+    sig_square = shape.sig.to_tuple()[0]
+    counter_depth = 6
+    header_string = get_header_string(shape.nav.size, counter_depth)
+    frame_header = get_frame_header_encoded(sig_square, counter_depth)
+
+    hdr_path = (datadir / 'default.hdr')
+    with hdr_path.open('wb') as fp:
+        fp.write(header_string.encode("ascii"))
+
+    with (datadir / 'default.mib').open('wb') as fp:
+        for idx in range(shape.nav.size):
+            fp.write(frame_header)
+            fp.write(np.full(shape.sig, idx, dtype=np.uint8).tobytes())
+    return str(hdr_path), shape, counter_depth
+
+
+@pytest.fixture(scope='module')
+def mock_merlin_ds(mock_mib_ds):
+    ctx = lt.Context.make_with('inline')
+    hdr_path, shape, _ = mock_mib_ds
+    return ctx.load(
+        'mib',
+        path=hdr_path,
+        nav_shape=shape.nav,
+    )
+
+
+@pytest.fixture(scope='module')
+def mock_merlin_triggered_sim_threads(mock_mib_ds):
+    '''
+    Untriggered non-garbage simulator.
+    '''
+    hdr_path, shape, counter_depth = mock_mib_ds
+    sigy, sigx = shape.sig
+    yield from run_merlin_sim(
+        path=hdr_path,
+        nav_shape=tuple(shape.nav),
+        initial_params={
+            'IMAGEX': f"{sigx}",
+            'IMAGEY': f"{sigy}",
+            'COUNTERDEPTH': f'{counter_depth}',
+        },
+    )
+
+
+@pytest.fixture(scope='module')
+def mock_merlin_detector_sim(mock_merlin_triggered_sim_threads):
+    '''
+    Host, port tuple of the untriggered default simulator
+    '''
+    return mock_merlin_triggered_sim_threads.server_t.sockname
+
+
+@pytest.fixture(scope='module')
+def mock_merlin_control_sim(mock_merlin_triggered_sim_threads):
+    '''
+    Host, port tuple of the control port for the triggered simulator
+    '''
+    return mock_merlin_triggered_sim_threads.control_t.sockname
+
+
+@pytest.fixture(scope='function')
+def mock_ds_conn(
+    ctx_pipelined: LiveContext,
+    mock_merlin_detector_sim,
+    mock_merlin_control_sim,  # XXX not really the matching control, but it kinda works...
+):
+    host, port = mock_merlin_detector_sim
+    api_host, api_port = mock_merlin_control_sim
+    with ctx_pipelined.make_connection('merlin').open(
+        data_host=host,
+        data_port=port,
+        api_host=api_host,
+        api_port=api_port,
+        drain=False,
+    ) as conn:
+        yield conn

--- a/tests/detectors/merlin/test_merlin_mockds.py
+++ b/tests/detectors/merlin/test_merlin_mockds.py
@@ -6,6 +6,8 @@ from libertem.io.dataset.base import DataSet
 
 from libertem_live.api import Hooks, LiveContext
 from libertem_live.hooks import ReadyForDataEnv
+from libertem_live.detectors.merlin.control import MerlinControl
+from libertem_live.detectors.merlin.sim import TriggerClient
 
 
 class MyHooks(Hooks):
@@ -66,3 +68,50 @@ def test_passive_acquisition(
     ref = ctx_pipelined.run_udf(dataset=mock_merlin_ds, udf=udf)
 
     assert_allclose(res['intensity'], ref['intensity'])
+
+
+class TriggerHooks(Hooks):
+    def __init__(self, control_t, trigger_t):
+        self._control_t = control_t
+        self._trigger_t = trigger_t
+
+    def on_ready_for_data(self, env: ReadyForDataEnv):
+        control = MerlinControl(*self._control_t)
+        with control:
+            control.cmd('STARTACQUISITION')
+        tr = TriggerClient(*self._trigger_t)
+        print("Trigger connection:", self._trigger_t)
+        tr.connect()
+        tr.trigger()
+        tr.close()
+
+
+def test_acquisition_triggered_garbage(
+    ctx_pipelined: LiveContext,
+    mock_merlin_ds,
+    mock_merlin_detector_sim_garbage,
+    mock_merlin_trigger_sim_garbage,
+    mock_merlin_control_sim_garbage,
+):
+    host, port = mock_merlin_detector_sim_garbage
+    api_host, api_port = mock_merlin_control_sim_garbage
+    with ctx_pipelined.make_connection('merlin').open(
+        data_host=host,
+        data_port=port,
+        api_host=api_host,
+        api_port=api_port,
+        drain=True,
+    ) as conn:
+        aq = ctx_pipelined.make_acquisition(
+            conn=conn,
+            hooks=TriggerHooks(
+                mock_merlin_control_sim_garbage,
+                mock_merlin_trigger_sim_garbage
+            ),
+            nav_shape=mock_merlin_ds.shape.nav,
+        )
+        udf = SumUDF()
+
+        res = ctx_pipelined.run_udf(dataset=aq, udf=udf)
+        ref = ctx_pipelined.run_udf(dataset=mock_merlin_ds, udf=udf)
+        assert_allclose(res['intensity'], ref['intensity'])

--- a/tests/detectors/merlin/test_merlin_mockds.py
+++ b/tests/detectors/merlin/test_merlin_mockds.py
@@ -1,0 +1,68 @@
+import numpy as np
+from numpy.testing import assert_allclose
+
+from libertem.udf.sum import SumUDF
+from libertem.io.dataset.base import DataSet
+
+from libertem_live.api import Hooks, LiveContext
+from libertem_live.hooks import ReadyForDataEnv
+
+
+class MyHooks(Hooks):
+    def __init__(self, triggered: np.ndarray, merlin_ds: "DataSet"):
+        self.ds = merlin_ds
+        self.triggered = triggered
+
+    def on_ready_for_data(self, env: ReadyForDataEnv):
+        self.triggered[:] = True
+        assert env.aq.shape.nav == self.ds.shape.nav
+
+
+def test_acquisition(
+    ctx_pipelined: LiveContext,
+    mock_merlin_ds,
+    mock_ds_conn,
+):
+    triggered = np.array((False,))
+
+    aq = ctx_pipelined.make_acquisition(
+        conn=mock_ds_conn,
+        hooks=MyHooks(triggered=triggered, merlin_ds=mock_merlin_ds),
+        nav_shape=mock_merlin_ds.shape.nav,
+    )
+    udf = SumUDF()
+
+    assert not triggered[0]
+    res = ctx_pipelined.run_udf(dataset=aq, udf=udf)
+    assert triggered[0]
+
+    ref = ctx_pipelined.run_udf(dataset=mock_merlin_ds, udf=udf)
+
+    assert_allclose(res['intensity'], ref['intensity'])
+
+
+def test_passive_acquisition(
+    ctx_pipelined: LiveContext,
+    mock_merlin_ds,
+    mock_ds_conn,
+):
+    triggered = np.array((False,))
+
+    pending_aq = mock_ds_conn.wait_for_acquisition(10.0)
+    assert pending_aq is not None
+
+    aq = ctx_pipelined.make_acquisition(
+        conn=mock_ds_conn,
+        hooks=MyHooks(triggered=triggered, merlin_ds=mock_merlin_ds),
+        pending_aq=pending_aq,
+        nav_shape=mock_merlin_ds.shape.nav,
+    )
+    udf = SumUDF()
+
+    assert not triggered[0]
+    res = ctx_pipelined.run_udf(dataset=aq, udf=udf)
+    assert not triggered[0]  # in passive mode, we don't call the on_ready_for_data hook
+
+    ref = ctx_pipelined.run_udf(dataset=mock_merlin_ds, udf=udf)
+
+    assert_allclose(res['intensity'], ref['intensity'])


### PR DESCRIPTION
Adds generation of a small fake MIB dataset which can run in the simulator and be tested.

Adds a test for passive mode, active mode, and trigger + garbage active mode.

In the future could add tests for raw mode rather than just integer mode, and also add this dataset generation to LiberTEM.


## Contributor Checklist:

* [x] I have added or updated my entry in [the creators.json file](https://github.com/LiberTEM/LiberTEM/blob/master/packaging/creators.json)
* [x] I have added [a changelog entry](https://github.com/LiberTEM/LiberTEM/tree/master/docs/source/changelog) for my contribution
* [ ] I have added/updated documentation for all user-facing changes
* [x] I have added/updated test cases

## Reviewer Checklist:

* [x] `/azp run libertem.libertem-live-data` passed