### PR TITLE
No memfd mock

### DIFF
--- a/tests/detectors/asi_tpx3/test_asi_tpx3_sim.py
+++ b/tests/detectors/asi_tpx3/test_asi_tpx3_sim.py
@@ -2,6 +2,7 @@
 Extra tests to get coverage for the simulator configurations
 """
 import os
+import platform
 from contextlib import contextmanager
 
 import pytest
@@ -50,10 +51,10 @@ def test_memfd_smoke(ctx_pipelined: LiveContext, tpx_testdata_path):
 
 
 def test_memfd_mock_data(ctx_pipelined: LiveContext):
-    try:
-        import memfd  # noqa
-    except ImportError:
-        pytest.skip("need pymemfd for this test (Linux only)")
+
+    cached = None
+    if platform.system() == 'Linux':
+        cached = 'MEM'
 
     sim_ctx_mgr = contextmanager(run_camera_sim)
 
@@ -62,7 +63,7 @@ def test_memfd_mock_data(ctx_pipelined: LiveContext):
         mock_nav_shape=(32, 32),
         port=0,
         sleep=0.1,
-        cached='MEMFD',
+        cached=cached,
     ) as tpx_sim:
         with ctx_pipelined.make_connection('asi_tpx3').open(
             data_port=tpx_sim.server_t.port,

--- a/tests/detectors/asi_tpx3/test_asi_tpx3_sim.py
+++ b/tests/detectors/asi_tpx3/test_asi_tpx3_sim.py
@@ -53,8 +53,12 @@ def test_memfd_smoke(ctx_pipelined: LiveContext, tpx_testdata_path):
 def test_memfd_mock_data(ctx_pipelined: LiveContext):
 
     cached = None
-    if platform.system() == 'Linux':
-        cached = 'MEM'
+    try:
+        import pymemfd  # noqa
+        cached = 'MEMFD'
+    except ImportError:
+        if platform.system() == 'Linux':
+            cached = 'MEM'
 
     sim_ctx_mgr = contextmanager(run_camera_sim)
 

--- a/tests/detectors/merlin/conftest.py
+++ b/tests/detectors/merlin/conftest.py
@@ -355,7 +355,7 @@ def mock_merlin_triggered_garbage(mock_mib_ds):
     sigy, sigx = shape.sig
     cached = None
     if platform.system() == 'Linux':
-        cached = 'MEMFD'
+        cached = 'MEM'
     yield from run_merlin_sim(
         path=hdr_path,
         cached=cached,

--- a/tests/detectors/merlin/conftest.py
+++ b/tests/detectors/merlin/conftest.py
@@ -354,8 +354,12 @@ def mock_merlin_triggered_garbage(mock_mib_ds):
     hdr_path, shape, counter_depth = mock_mib_ds
     sigy, sigx = shape.sig
     cached = None
-    if platform.system() == 'Linux':
-        cached = 'MEM'
+    try:
+        import pymemfd  # noqa
+        cached = 'MEMFD'
+    except ImportError:
+        if platform.system() == 'Linux':
+            cached = 'MEM'
     yield from run_merlin_sim(
         path=hdr_path,
         cached=cached,


### PR DESCRIPTION
Because we can't install `pymemfd` from conda we can't rely on being able to install it during testing in there pipeline when we have no data.

This PR switches the cache to `MEM` on linux if `pymemfd` is unavailable. On other platforms no caching is used in the mock tests, as before.

## Contributor Checklist:

* [x] I have added or updated my entry in [the creators.json file](https://github.com/LiberTEM/LiberTEM/blob/master/packaging/creators.json)
* [ ] I have added [a changelog entry](https://github.com/LiberTEM/LiberTEM/tree/master/docs/source/changelog) for my contribution
* [ ] I have added/updated documentation for all user-facing changes
* [x] I have added/updated test cases

## Reviewer Checklist:

* [ ] `/azp run libertem.libertem-live-data` passed