### PR TITLE
Limit number of workers for testing

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -9,6 +9,7 @@ from contextlib import contextmanager
 from libertem.executor.inline import InlineJobExecutor
 from libertem.executor.pipelined import PipelinedExecutor
 
+import psutil
 import pytest
 import numpy as np
 
@@ -61,7 +62,15 @@ def ltl_ctx_fast():
 def ctx_pipelined():
     executor = None
     try:
-        executor = PipelinedExecutor()
+        num_cpus = min(
+            psutil.cpu_count(logical=False),
+            4
+        )
+        spec = PipelinedExecutor.make_spec(
+            cpus=num_cpus,
+            cudas=0,
+        )
+        executor = PipelinedExecutor(spec=spec)
         yield ltl.LiveContext(executor=executor, plot_class=Dummy2DPlot)
     finally:
         if executor is not None:

--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -12,3 +12,4 @@ pymemfd; platform_system=="Linux"
 python-prctl; platform_system=="Linux"
 libertem[bqplot]
 flask
+psutil


### PR DESCRIPTION
In CI, there are possibly parallel test runs that oversubscribe the CPU. Limit to a max of 4 workers to prevent this.

## Contributor Checklist:

* [ ] I have added or updated my entry in [the creators.json file](https://github.com/LiberTEM/LiberTEM/blob/master/packaging/creators.json)
* [ ] I have added [a changelog entry](https://github.com/LiberTEM/LiberTEM/tree/master/docs/source/changelog) for my contribution
* [ ] I have added/updated documentation for all user-facing changes
* [ ] I have added/updated test cases

## Reviewer Checklist:

* [x] `/azp run libertem.libertem-live-data` passed

<!--

Starting by submitting an incomplete pull request (PR) or draft PR is OK. You
can work on the checklist step by step by pushing additional commits into the
PR. Please indicate if you think some items may not be applicable.

You can have a look at [our contributing
docs](https://libertem.github.io/LiberTEM/contributing.html) for more
information on contributing to LiberTEM. Please feel free to ask for
clarification and help, for example in your PR description, with comments or in
our [Gitter channel](https://gitter.im/LiberTEM/Lobby).

Thank you for your contribution!

-->
