### PR TITLE
Fix for nav_shape != (32, 32) in asi tpx3 sim

### DIFF
--- a/src/libertem_live/detectors/asi_tpx3/sim.py
+++ b/src/libertem_live/detectors/asi_tpx3/sim.py
@@ -78,7 +78,9 @@ class BufferedCachedSource(CachedDataSource):
         for idx in range(prod(mock_nav_shape)):
             arr[idx, idx % sig_size] = idx
         c = sparseconverter.for_backend(arr, 'scipy.sparse.csr_matrix', strict=True)
-        mock_data = np.array(make_sim_data((32, 32), c.indptr, c.indices, c.data), dtype='uint8')
+        mock_data = np.array(make_sim_data(
+            mock_nav_shape, c.indptr, c.indices, c.data
+        ), dtype='uint8')
         return mock_data
 
     def _cache_data(self, paths: List[str]):

--- a/tests/detectors/asi_tpx3/test_asi_tpx3_sim.py
+++ b/tests/detectors/asi_tpx3/test_asi_tpx3_sim.py
@@ -75,3 +75,26 @@ def test_memfd_mock_data(ctx_pipelined: LiveContext):
             )
             res = ctx_pipelined.run_udf(dataset=aq, udf=SumSigUDF())
             assert not np.allclose(res['intensity'], 0)
+
+
+def test_mock_data_shape(ctx_pipelined: LiveContext):
+    sim_ctx_mgr = contextmanager(run_camera_sim)
+
+    with sim_ctx_mgr(
+        cls=TpxCameraSim,
+        mock_nav_shape=(64, 64),
+        port=0,
+        sleep=0.1,
+        cached='MEM',
+    ) as tpx_sim:
+        with ctx_pipelined.make_connection('asi_tpx3').open(
+            data_port=tpx_sim.server_t.port,
+        ) as conn:
+            pending_aq = conn.wait_for_acquisition(10.0)
+            assert pending_aq is not None
+            aq = ctx_pipelined.make_acquisition(
+                conn=conn,
+                pending_aq=pending_aq,
+            )
+            res = ctx_pipelined.run_udf(dataset=aq, udf=SumSigUDF())
+            assert not np.allclose(res['intensity'], 0)


### PR DESCRIPTION
## Contributor Checklist:

* [ ] I have added or updated my entry in [the creators.json file](https://github.com/LiberTEM/LiberTEM/blob/master/packaging/creators.json)
* [ ] I have added [a changelog entry](https://github.com/LiberTEM/LiberTEM/tree/master/docs/source/changelog) for my contribution
* [ ] I have added/updated documentation for all user-facing changes
* [ ] I have added/updated test cases

## Reviewer Checklist:

* [x] `/azp run libertem.libertem-live-data` passed

<!--

Starting by submitting an incomplete pull request (PR) or draft PR is OK. You
can work on the checklist step by step by pushing additional commits into the
PR. Please indicate if you think some items may not be applicable.

You can have a look at [our contributing
docs](https://libertem.github.io/LiberTEM/contributing.html) for more
information on contributing to LiberTEM. Please feel free to ask for
clarification and help, for example in your PR description, with comments or in
our [Gitter channel](https://gitter.im/LiberTEM/Lobby).

Thank you for your contribution!

-->
