### PR TITLE
No need to warmup with such a large `stop_before_frame` value

### DIFF
--- a/src/libertem_live/detectors/merlin/sim.py
+++ b/src/libertem_live/detectors/merlin/sim.py
@@ -290,7 +290,7 @@ class DataSocketSimulator:
         )
         slices, ranges, scheme_indices = fileset.get_read_ranges(
             start_at_frame=0,
-            stop_before_frame=int(np.prod(self._ds.shape.nav)),
+            stop_before_frame=min(10, int(np.prod(self._ds.shape.nav))),
             dtype=np.float32,  # FIXME: don't really care...
             tiling_scheme=tiling_scheme,
             roi=None,


### PR DESCRIPTION
In real usage, the number of frames per partition is a lot smaller...

## Contributor Checklist:

* [ ] I have added or updated my entry in [the creators.json file](https://github.com/LiberTEM/LiberTEM/blob/master/packaging/creators.json)
* [ ] I have added [a changelog entry](https://github.com/LiberTEM/LiberTEM/tree/master/docs/source/changelog) for my contribution
* [ ] I have added/updated documentation for all user-facing changes
* [ ] I have added/updated test cases

## Reviewer Checklist:

* [x] `/azp run libertem.libertem-live-data` passed

<!--

Starting by submitting an incomplete pull request (PR) or draft PR is OK. You
can work on the checklist step by step by pushing additional commits into the
PR. Please indicate if you think some items may not be applicable.

You can have a look at [our contributing
docs](https://libertem.github.io/LiberTEM/contributing.html) for more
information on contributing to LiberTEM. Please feel free to ask for
clarification and help, for example in your PR description, with comments or in
our [Gitter channel](https://gitter.im/LiberTEM/Lobby).

Thank you for your contribution!

-->
