### PR TITLE
Fix deprecation warning on sparse.COO coords

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -15,3 +15,5 @@ log_level=INFO
 log_format = %(asctime)s %(msecs)3d %(name)s %(levelname)s %(message)s
 log_date_format = %Y-%m-%d %H:%M:%S
 asyncio_mode = auto
+filterwarnings =
+    error:coords should be an ndarray:DeprecationWarning

--- a/tests/detectors/dectris/test_dectris.py
+++ b/tests/detectors/dectris/test_dectris.py
@@ -100,7 +100,7 @@ def test_udf_sig(ctx_pipelined: LiveContext, dectris_sim):
 
         corr = CorrectionSet(
             excluded_pixels=sparse.COO(
-                coords=(bad_y, bad_x),
+                coords=np.asarray((bad_y, bad_x)),
                 data=1,
                 shape=aq.shape.sig
             )

--- a/tests/detectors/dectris/test_dectris.py
+++ b/tests/detectors/dectris/test_dectris.py
@@ -100,7 +100,7 @@ def test_udf_sig(ctx_pipelined: LiveContext, dectris_sim):
 
         corr = CorrectionSet(
             excluded_pixels=sparse.COO(
-                coords=np.asarray((bad_y, bad_x)),
+                coords=np.stack((bad_y, bad_x), axis=0),
                 data=1,
                 shape=aq.shape.sig
             )


### PR DESCRIPTION
Like https://github.com/LiberTEM/LiberTEM/pull/1699 - fix remaining `DeprecationWarning`.

## Contributor Checklist:

* [ ] I have added or updated my entry in [the creators.json file](https://github.com/LiberTEM/LiberTEM/blob/master/packaging/creators.json)
* [ ] I have added [a changelog entry](https://github.com/LiberTEM/LiberTEM/tree/master/docs/source/changelog) for my contribution
* [ ] I have added/updated documentation for all user-facing changes
* [ ] I have added/updated test cases

## Reviewer Checklist:

* [ ] `/azp run libertem.libertem-live-data` passed

<!--

Starting by submitting an incomplete pull request (PR) or draft PR is OK. You
can work on the checklist step by step by pushing additional commits into the
PR. Please indicate if you think some items may not be applicable.

You can have a look at [our contributing
docs](https://libertem.github.io/LiberTEM/contributing.html) for more
information on contributing to LiberTEM. Please feel free to ask for
clarification and help, for example in your PR description, with comments or in
our [Gitter channel](https://gitter.im/LiberTEM/Lobby).

Thank you for your contribution!

-->
